### PR TITLE
fix for no pc update when str or load instruction

### DIFF
--- a/riscv_core/riscv_core.srcs/sources_1/new/riscv_core.sv
+++ b/riscv_core/riscv_core.srcs/sources_1/new/riscv_core.sv
@@ -414,12 +414,12 @@ generate
    
    // ---------- (1) PC -------------------------------------
    assign reset_a0 = reset;
-   assign pc[31:0] = next_pc_a1;
+   assign pc[31:0] = (is_load || is_s_instr)? pc : next_pc_a1;
    assign next_pc[31:0] = reset_a0 ? 32'b0 :
                           (taken_br === 1) ? br_tgt_pc :
                           (is_jal === 1) ? br_tgt_pc :
                           (is_jalr === 1) ? jalr_tgt_pc :
-                          (no_op === 1) ? pc :
+                          (no_op === 1) ? next_pc_a1 :
                           pc + 32'd4;
   
    // ---------- (2) IMEM -----------------------------------

--- a/riscv_core/riscv_core.srcs/sources_1/new/riscv_core.sv
+++ b/riscv_core/riscv_core.srcs/sources_1/new/riscv_core.sv
@@ -177,6 +177,7 @@ logic imm_valid;
 
 // For $instr.
 logic [31:0] instr;
+logic [31:0] instr_a0;
 
 // For $is_add.
 logic is_add;
@@ -301,6 +302,7 @@ logic [6:0] opcode;
 
 // For $pc.
 logic [31:0] pc;
+logic [31:0] last_pc;
 
 // For $rd.
 logic [4:0] rd;
@@ -377,6 +379,8 @@ logic [32-1:0] Xreg_value_n1 [31:0],
                
 logic no_op;
 logic[1:0] ld_done;
+logic [32-1:0] addr_read;
+logic [32-1:0] last_read_addr;
              
  
 
@@ -387,6 +391,8 @@ generate
 
    // For $next_pc.
    always_ff @(posedge clk) begin
+        last_read_addr <= addr_read;
+        last_pc <= pc;
         next_pc_a1[31:0] <= next_pc[31:0];
         state <= next_state;
    end
@@ -414,7 +420,9 @@ generate
    
    // ---------- (1) PC -------------------------------------
    assign reset_a0 = reset;
-   assign pc[31:0] = (is_load || is_s_instr)? pc : next_pc_a1;
+   assign pc[31:0] = (is_load)? last_pc :
+                     (is_s_instr)? pc : 
+                        next_pc_a1;
    assign next_pc[31:0] = reset_a0 ? 32'b0 :
                           (taken_br === 1) ? br_tgt_pc :
                           (is_jal === 1) ? br_tgt_pc :
@@ -436,6 +444,8 @@ generate
         state = DECODE;
         mem_wr_data = 32'b0;
    end */
+   assign instr = (last_pc != last_read_addr && state == FETCH) ?  32'b0 : instr_a0;
+ //  assign instr = (state === STR) ? instr_a0 : instr;
    
    assign is_u_instr = instr[6:2] == 5'b00101 ||
                        instr[6:2] == 5'b01101;
@@ -672,6 +682,7 @@ generate
             case(state)
                 FETCH: begin
                     rv_m_addr = pc;
+                    addr_read = pc;
                     rv_m_rw = 1'b0;
                     rv_m_valid = 1'b1;
                     rv_m_wrdata[32-1:0] = 32'b0;
@@ -679,6 +690,7 @@ generate
                 end   
                 DECODE: begin
                     rv_m_addr = pc;
+                    addr_read = pc;
                     rv_m_rw = 1'b0;
                     rv_m_valid = 1'b0;
                     rv_m_wrdata = 32'b0;
@@ -686,6 +698,7 @@ generate
                 end
                 LD: begin
                     rv_m_addr = result;
+                    addr_read = result;
                     rv_m_rw = 1'b0;
                     rv_m_valid = 1'b1;
                     rv_m_wrdata[32-1:0] = 32'b0;
@@ -693,6 +706,7 @@ generate
                 end
                 STR: begin   
                     rv_m_addr = result;  
+                    addr_read = pc;
                     rv_m_rw = 1'b1;
                     rv_m_valid = 1'b1;
                     rv_m_wrdata[32-1:0] = src2_value;
@@ -703,7 +717,7 @@ generate
        //----------------------------MEM------------------------------------------
        always @ * begin
            if (state == FETCH || state == DECODE) begin
-                instr = rv_m_rdata;
+                instr_a0 = rv_m_rdata;
                 ld_data = 32'b0;
                 ld_done = 2'b00;
            end 

--- a/riscv_core/riscv_core.xpr
+++ b/riscv_core/riscv_core.xpr
@@ -48,7 +48,7 @@
     <Option Name="IPStaticSourceDir" Val="$PIPUSERFILESDIR/ipstatic"/>
     <Option Name="EnableBDX" Val="FALSE"/>
     <Option Name="DSABoardId" Val="zed"/>
-    <Option Name="WTXSimLaunchSim" Val="454"/>
+    <Option Name="WTXSimLaunchSim" Val="503"/>
     <Option Name="WTModelSimLaunchSim" Val="0"/>
     <Option Name="WTQuestaLaunchSim" Val="0"/>
     <Option Name="WTIesLaunchSim" Val="0"/>

--- a/riscv_core/riscv_core.xpr
+++ b/riscv_core/riscv_core.xpr
@@ -48,7 +48,7 @@
     <Option Name="IPStaticSourceDir" Val="$PIPUSERFILESDIR/ipstatic"/>
     <Option Name="EnableBDX" Val="FALSE"/>
     <Option Name="DSABoardId" Val="zed"/>
-    <Option Name="WTXSimLaunchSim" Val="503"/>
+    <Option Name="WTXSimLaunchSim" Val="513"/>
     <Option Name="WTModelSimLaunchSim" Val="0"/>
     <Option Name="WTQuestaLaunchSim" Val="0"/>
     <Option Name="WTIesLaunchSim" Val="0"/>

--- a/riscv_core/testbench_behav.wcfg
+++ b/riscv_core/testbench_behav.wcfg
@@ -11,15 +11,15 @@
       </db_ref>
    </db_ref_list>
    <zoom_setting>
-      <ZoomStartTime time="555905fs"></ZoomStartTime>
-      <ZoomEndTime time="598556fs"></ZoomEndTime>
-      <Cursor1Time time="585100fs"></Cursor1Time>
+      <ZoomStartTime time="0fs"></ZoomStartTime>
+      <ZoomEndTime time="230fs"></ZoomEndTime>
+      <Cursor1Time time="72fs"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
-      <NameColumnWidth column_width="117"></NameColumnWidth>
+      <NameColumnWidth column_width="81"></NameColumnWidth>
       <ValueColumnWidth column_width="58"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="23" />
+   <WVObjectSize size="33" />
    <wave_markers>
       <marker time="40000" label="" />
       <marker time="65000" label="" />
@@ -68,6 +68,14 @@
       <obj_property name="ElementShortName">is_load</obj_property>
       <obj_property name="ObjectShortName">is_load</obj_property>
    </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/instr" type="array">
+      <obj_property name="ElementShortName">instr[31:0]</obj_property>
+      <obj_property name="ObjectShortName">instr[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/no_op" type="logic">
+      <obj_property name="ElementShortName">no_op</obj_property>
+      <obj_property name="ObjectShortName">no_op</obj_property>
+   </wvobject>
    <wvobject fp_name="/top_soc_tb/dut/your_instance_name/s_axi_bvalid" type="logic">
       <obj_property name="ElementShortName">s_axi_bvalid</obj_property>
       <obj_property name="ObjectShortName">s_axi_bvalid</obj_property>
@@ -95,15 +103,10 @@
    <wvobject fp_name="/top_soc_tb/dut/cpu/xreg_out" type="array">
       <obj_property name="ElementShortName">xreg_out[31:0][31:0]</obj_property>
       <obj_property name="ObjectShortName">xreg_out[31:0][31:0]</obj_property>
-      <obj_property name="isExpanded"></obj_property>
    </wvobject>
    <wvobject fp_name="/top_soc_tb/dut/cpu/mem_done" type="array">
       <obj_property name="ElementShortName">mem_done[1:0]</obj_property>
       <obj_property name="ObjectShortName">mem_done[1:0]</obj_property>
-   </wvobject>
-   <wvobject fp_name="/top_soc_tb/dut/cpu/pc" type="array">
-      <obj_property name="ElementShortName">pc[31:0]</obj_property>
-      <obj_property name="ObjectShortName">pc[31:0]</obj_property>
    </wvobject>
    <wvobject fp_name="/top_soc_tb/dut/cpu/rf_wr_en" type="logic">
       <obj_property name="ElementShortName">rf_wr_en</obj_property>
@@ -113,8 +116,44 @@
       <obj_property name="ElementShortName">rf_wr_data[31:0]</obj_property>
       <obj_property name="ObjectShortName">rf_wr_data[31:0]</obj_property>
    </wvobject>
-   <wvobject fp_name="/top_soc_tb/dut/cpu/ld_done" type="logic">
-      <obj_property name="ElementShortName">ld_done</obj_property>
-      <obj_property name="ObjectShortName">ld_done</obj_property>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/ld_done" type="array">
+      <obj_property name="ElementShortName">ld_done[1:0]</obj_property>
+      <obj_property name="ObjectShortName">ld_done[1:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/pc" type="array">
+      <obj_property name="ElementShortName">pc[31:0]</obj_property>
+      <obj_property name="ObjectShortName">pc[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/next_pc_a1" type="array">
+      <obj_property name="ElementShortName">next_pc_a1[31:0]</obj_property>
+      <obj_property name="ObjectShortName">next_pc_a1[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/next_pc" type="array">
+      <obj_property name="ElementShortName">next_pc[31:0]</obj_property>
+      <obj_property name="ObjectShortName">next_pc[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/last_pc" type="array">
+      <obj_property name="ElementShortName">last_pc[31:0]</obj_property>
+      <obj_property name="ObjectShortName">last_pc[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/is_auipc" type="logic">
+      <obj_property name="ElementShortName">is_auipc</obj_property>
+      <obj_property name="ObjectShortName">is_auipc</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/is_xori" type="logic">
+      <obj_property name="ElementShortName">is_xori</obj_property>
+      <obj_property name="ObjectShortName">is_xori</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/is_addi" type="logic">
+      <obj_property name="ElementShortName">is_addi</obj_property>
+      <obj_property name="ObjectShortName">is_addi</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/last_read_addr" type="array">
+      <obj_property name="ElementShortName">last_read_addr[31:0]</obj_property>
+      <obj_property name="ObjectShortName">last_read_addr[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/addr_read" type="array">
+      <obj_property name="ElementShortName">addr_read[31:0]</obj_property>
+      <obj_property name="ObjectShortName">addr_read[31:0]</obj_property>
    </wvobject>
 </wave_config>

--- a/riscv_core/testbench_behav.wcfg
+++ b/riscv_core/testbench_behav.wcfg
@@ -11,15 +11,15 @@
       </db_ref>
    </db_ref_list>
    <zoom_setting>
-      <ZoomStartTime time="0fs"></ZoomStartTime>
-      <ZoomEndTime time="230fs"></ZoomEndTime>
-      <Cursor1Time time="72fs"></Cursor1Time>
+      <ZoomStartTime time="443800fs"></ZoomStartTime>
+      <ZoomEndTime time="517701fs"></ZoomEndTime>
+      <Cursor1Time time="455100fs"></Cursor1Time>
    </zoom_setting>
    <column_width_setting>
-      <NameColumnWidth column_width="81"></NameColumnWidth>
-      <ValueColumnWidth column_width="58"></ValueColumnWidth>
+      <NameColumnWidth column_width="198"></NameColumnWidth>
+      <ValueColumnWidth column_width="91"></ValueColumnWidth>
    </column_width_setting>
-   <WVObjectSize size="33" />
+   <WVObjectSize size="37" />
    <wave_markers>
       <marker time="40000" label="" />
       <marker time="65000" label="" />
@@ -103,6 +103,7 @@
    <wvobject fp_name="/top_soc_tb/dut/cpu/xreg_out" type="array">
       <obj_property name="ElementShortName">xreg_out[31:0][31:0]</obj_property>
       <obj_property name="ObjectShortName">xreg_out[31:0][31:0]</obj_property>
+      <obj_property name="isExpanded"></obj_property>
    </wvobject>
    <wvobject fp_name="/top_soc_tb/dut/cpu/mem_done" type="array">
       <obj_property name="ElementShortName">mem_done[1:0]</obj_property>
@@ -140,6 +141,10 @@
       <obj_property name="ElementShortName">is_auipc</obj_property>
       <obj_property name="ObjectShortName">is_auipc</obj_property>
    </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/is_srli" type="logic">
+      <obj_property name="ElementShortName">is_srli</obj_property>
+      <obj_property name="ObjectShortName">is_srli</obj_property>
+   </wvobject>
    <wvobject fp_name="/top_soc_tb/dut/cpu/is_xori" type="logic">
       <obj_property name="ElementShortName">is_xori</obj_property>
       <obj_property name="ObjectShortName">is_xori</obj_property>
@@ -155,5 +160,17 @@
    <wvobject fp_name="/top_soc_tb/dut/cpu/addr_read" type="array">
       <obj_property name="ElementShortName">addr_read[31:0]</obj_property>
       <obj_property name="ObjectShortName">addr_read[31:0]</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/is_jal" type="logic">
+      <obj_property name="ElementShortName">is_jal</obj_property>
+      <obj_property name="ObjectShortName">is_jal</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/is_jalr" type="logic">
+      <obj_property name="ElementShortName">is_jalr</obj_property>
+      <obj_property name="ObjectShortName">is_jalr</obj_property>
+   </wvobject>
+   <wvobject fp_name="/top_soc_tb/dut/cpu/br_tgt_pc" type="array">
+      <obj_property name="ElementShortName">br_tgt_pc[31:0]</obj_property>
+      <obj_property name="ObjectShortName">br_tgt_pc[31:0]</obj_property>
    </wvobject>
 </wave_config>


### PR DESCRIPTION
- fixes #10 
- still needs more testing
- `auipc` instruction not working well, maybe add `pc-32'd4 + immm`

`pc` is :
 - `last_pc` if  _LD instr_
 - `pc` if _STR instr_
 - `next_pc_a1` in other instructions 
 
Every state writes `addr_read` to remember from which address is last data, this is needed because _LD instr_ could read data that is actually new instruction and then FETCH will execute that instruction and that is not what we want to do. Because of that check is added to see if `instr` is valid: 
` assign instr = (last_pc != last_read_addr && state == FETCH) ?  32'b0 : instr_a0;`


`addr_read` is: 
- `pc` in _STR or FETCH_ state
- `result` in _LD_ state

